### PR TITLE
Implement network segmentation for improved isolation and security

### DIFF
--- a/common/caddy/docker-compose.yaml
+++ b/common/caddy/docker-compose.yaml
@@ -6,6 +6,9 @@ services:
   caddy:
     image: caddy:2.8
     restart: always
+    networks:
+      - kong_caddy_network
+      - default
     cap_add:
       - NET_ADMIN
     ports:

--- a/common/db/docker-compose.yaml
+++ b/common/db/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   db:
     image: postgres:17.2
     restart: always
+    networks:
+      - backend_network
     volumes:
       - db:/var/lib/postgresql/data
     healthcheck:

--- a/common/kong/docker-compose.yaml
+++ b/common/kong/docker-compose.yaml
@@ -2,6 +2,9 @@ services:
   kong:
     image: kong:3.6.1
     user: kong
+    networks:
+      - gateway_network
+      - kong_caddy_network
     environment:
       KONG_DATABASE: off
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
@@ -24,3 +27,10 @@ services:
     restart: always
     volumes:
       - ./:/opt/kong
+
+
+networks:
+  gateway_network:
+    driver: bridge
+  kong_caddy_network:
+    driver: bridge

--- a/common/minio/docker-compose.yaml
+++ b/common/minio/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
   minio:
     image: minio/minio
     restart: always
+    networks: 
+      - backend_network
     volumes:
       - minio:/data
     environment:
@@ -14,6 +16,8 @@ services:
 
   minio_helper:
     image: minio/mc
+    networks: 
+      - backend_network
     volumes:
       - './kickstart.sh:/etc/minio/kickstart.sh'
     entrypoint: /etc/minio/kickstart.sh

--- a/common/redis/docker-compose.yaml
+++ b/common/redis/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   redis:
     image: redis:latest
     restart: always
+    networks: 
+      - backend_network
     command: [ 'redis-server', '--appendonly', 'yes' ]
     volumes:
       - redis:/data

--- a/epic/epic_global_ai/docker-compose.yaml
+++ b/epic/epic_global_ai/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   epic_global_ai:
       image: ghcr.io/${org}/epic-global-ai-services:${EPIC_GLOBAL_AI_IMAGE_TAG:-${DEFAULT_IMAGE_TAG:?DEFAULT_IMAGE_TAG is not set}}
       restart: always
+      networks:
+        - gateway_network
       environment:
         GOOGLE_AI_API_KEY: ${GOOGLE_AI_API_KEY:?GOOGLE_AI_API_KEY is not set}
         DATABASE_URI: ${DATABASE_URI:?DATABASE_URI is not set}
@@ -13,6 +15,8 @@ services:
   celery:
       image: ghcr.io/${org}/epic-global-ai-services:${EPIC_GLOBAL_AI_IMAGE_TAG:-${DEFAULT_IMAGE_TAG:?DEFAULT_IMAGE_TAG is not set}}
       restart: always
+      networks:
+        - ai_network
       command: celery -A app.utils.celery.celery worker --loglevel=info
       depends_on:
         - rabbitmq
@@ -28,10 +32,14 @@ services:
   redis-backend:
       image: redis:bookworm
       restart: always
+      networks:
+        - ai_network
 
   db-ai:
     image: postgres:14.15-alpine3.21
     restart: always
+    networks:
+      - ai_network
     volumes:
       - db-ai:/var/lib/postgresql/data
     healthcheck:
@@ -45,3 +53,7 @@ services:
 
 volumes:
   db-ai:
+
+networks:
+  ai_network:
+    driver: bridge

--- a/epic/epic_global_backend/docker-compose.yaml
+++ b/epic/epic_global_backend/docker-compose.yaml
@@ -2,6 +2,9 @@ services:
   epic_global_backend:
       image: ghcr.io/${org}/epic-global-backend:${EPIC_GLOBAL_BACKEND_IMAGE_TAG:-${DEFAULT_IMAGE_TAG:?DEFAULT_IMAGE_TAG is not set}}
       restart: always
+      networks: 
+        - backend_network
+        - gateway_network
       environment:
         DB_HOST: ${DB_HOST:?DB_HOST is not set}
         DB_NAME: ${DB_NAME:?DB_NAME is not set}
@@ -21,3 +24,7 @@ services:
         AMAZON_REFRESH_TOKEN: ${AMAZON_REFRESH_TOKEN:?AMAZON_REFRESH_TOKEN is not set}
         PRODUCT_LISTING_BASE_URL: ${PRODUCT_LISTING_BASE_URL:?PRODUCT_LISTING_BASE_URL is not set}
         AI_SERVICE_BASE_URL: ${AI_SERVICE_BASE_URL:?AI_SERVICE_BASE_URL is not set}
+
+networks:
+  backend_network:
+    driver: bridge


### PR DESCRIPTION
- Segmented Docker networks into dedicated buckets:
  - `backend_network`: Includes backend services like `epic_global_backend`, `db`, `redis`, and `minio`.
  - `gateway_network`: For API gateway services such as `epic_global_ai`, `epic_global_backend`, and `kong`.
  - `AI_network`: Isolated network for AI-related services like `epic_global_ai`, `celery`, `redis-backend`, and `db-ai`.
  - `kong-caddy-network`: For communication between `kong` and `caddy`.
  - `common_network`: Shared network for frontend, monitoring, and environment services.
- Added `epic_default` network explicitly to specific services where required.
- Improved service isolation to enhance security and minimize unnecessary communication.
- Ensures adherence to best practices in microservices architecture.

